### PR TITLE
leaders_from_score_range functionality

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -199,6 +199,13 @@ Get rank and score for an arbitrary list of members (e.g. friends) from the lead
    => [{:member=>"member_1", :rank=>56, :score=>1.0}, {:member=>"member_62", :rank=>34, :score=>62.0}, {:member=>"member_67", :rank=>29, :score=>67.0}]
 ```
 
+Retrieve members from the leaderboard in a given score range:
+
+```ruby
+leaders = highscore_lb.leaders_from_score_range(4, 19)
+ => [{:member=>"member_10", :rank=>47, :score=>10.0}, {:member=>"member_9", :rank=>48, :score=>9.0}, {:member=>"member_8", :rank=>49, :score=>8.0}, {:member=>"member_7", :rank=>50, :score=>7.0}, {:member=>"member_6", :rank=>51, :score=>6.0}, {:member=>"member_5", :rank=>52, :score=>5.0}, {:member=>"member_4", :rank=>53, :score=>4.0}] 
+```
+
 ### Ranking multiple members in a leaderboard at once 
 
 Insert multiple data items for members and their associated scores:

--- a/lib/leaderboard.rb
+++ b/lib/leaderboard.rb
@@ -531,6 +531,40 @@ class Leaderboard
       return []
     end
   end
+
+  # Retrieve leaders from the leaderboard within a given score range.
+  #
+  # @param minimum_score [float] Minimum score (inclusive).
+  # @param maximum_score [float] Maximum score (inclusive).
+  # @param options [Hash] Options to be used when retrieving the data from the leaderboard.
+  #
+  # @return leaders from the leaderboard that fall within the given score range.
+  def leaders_from_score_range(minimum_score, maximum_score, options = {})
+    leaders_from_score_range_in(@leaderboard_name, minimum_score, maximum_score, options)
+  end
+
+  # Retrieve leaders from the named leaderboard within a given score range.
+  #
+  # @param leaderboard_name [String] Name of the leaderboard.
+  # @param minimum_score [float] Minimum score (inclusive).
+  # @param maximum_score [float] Maximum score (inclusive).
+  # @param options [Hash] Options to be used when retrieving the data from the leaderboard.
+  #
+  # @return leaders from the leaderboard that fall within the given score range.
+  def leaders_from_score_range_in(leaderboard_name, minimum_score, maximum_score, options = {})
+    leaderboard_options = DEFAULT_LEADERBOARD_REQUEST_OPTIONS.dup
+    leaderboard_options.merge!(options)
+
+    raw_leader_data = @reverse ? 
+      @redis_connection.zrangebyscore(leaderboard_name, minimum_score, maximum_score, :with_scores => false) :
+      @redis_connection.zrevrangebyscore(leaderboard_name, maximum_score, minimum_score, :with_scores => false)
+
+    if raw_leader_data
+      return ranked_in_list_in(leaderboard_name, raw_leader_data, leaderboard_options)
+    else
+      return []
+    end
+  end
   
   # Retrieve a page of leaders from the leaderboard around a given member.
   #

--- a/spec/leaderboard_spec.rb
+++ b/spec/leaderboard_spec.rb
@@ -126,6 +126,26 @@ describe 'Leaderboard' do
     leaders.size.should be(1)
   end
 
+  it 'should allow you to retrieve leaders in a given score range' do
+    rank_members_in_leaderboard(Leaderboard::DEFAULT_PAGE_SIZE)
+
+    leaders = @leaderboard.leaders_from_score_range(10, 15, {:with_scores => false, :with_rank => false})
+
+    member_15 = {:member => 'member_15'}
+    leaders[0].should == member_15
+
+    member_10 = {:member => 'member_10'}
+    leaders[5].should == member_10
+
+    leaders = @leaderboard.leaders_from_score_range(10, 15, {:with_scores => true, :with_rank => true, :with_member_data => true})
+
+    member_15 = {:member => 'member_15', :rank => 11, :score => 15.0, :member_data => {'member_name' => 'Leaderboard member 15'}}
+    leaders[0].should == member_15
+
+    member_10 = {:member => 'member_10', :rank => 16, :score => 10.0, :member_data => {'member_name' => 'Leaderboard member 10'}}
+    leaders[5].should == member_10
+  end
+
   it 'should allow you to retrieve leaders without scores and ranks' do
     rank_members_in_leaderboard(Leaderboard::DEFAULT_PAGE_SIZE)
     

--- a/spec/reverse_leaderboard_spec.rb
+++ b/spec/reverse_leaderboard_spec.rb
@@ -33,6 +33,26 @@ describe 'Leaderboard (reverse option)' do
     leaders[-1][:score].to_i.should be(25)
   end
 
+  it 'should allow you to retrieve leaders in a given score range' do
+    rank_members_in_leaderboard(Leaderboard::DEFAULT_PAGE_SIZE)
+
+    leaders = @leaderboard.leaders_from_score_range(10, 15, {:with_scores => false, :with_rank => false})
+
+    member_10 = {:member => 'member_10'}
+    leaders[0].should == member_10
+
+    member_15 = {:member => 'member_15'}
+    leaders[5].should == member_15
+
+    leaders = @leaderboard.leaders_from_score_range(10, 15, {:with_scores => true, :with_rank => true, :with_member_data => true})
+
+    member_10 = {:member => 'member_10', :rank => 10, :score => 10.0, :member_data => {'member_name' => 'Leaderboard member 10'}}
+    leaders[0].should == member_10
+
+    member_15 = {:member => 'member_15', :rank => 15, :score => 15.0, :member_data => {'member_name' => 'Leaderboard member 15'}}
+    leaders[5].should == member_15
+  end
+
   it 'should allow you to retrieve leaders without scores and ranks' do
     rank_members_in_leaderboard(Leaderboard::DEFAULT_PAGE_SIZE)
     


### PR DESCRIPTION
* Added `leaders_from_score_range` and `leaders_from_score_range_in` methods and specs. This will retrieve leaders from the leaderboard that fall within a given score range.
* Updated README for `leaders_from_score_range` method.leaderboard